### PR TITLE
ci: flatpak: Update shipdriver templates.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,10 @@ jobs:
     resource_class: arm.medium
     environment:
       - OCPN_TARGET: flatpak-arm64
-      - FLATPAK_BRANCH: beta
     parameters:
       cache-key:
         type: string
-        default: "fp-arm20-v1"
+        default: "fp-arm20-v2"
     <<: *flatpak-steps
 
   build-flatpak-x86-1808:
@@ -43,11 +42,11 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
-      - FLATPAK_BRANCH: stable
+      - BUILD_1808: "true"
     parameters:
       cache-key:
         type: string
-        default: "fp-x86-18-v1"
+        default: "fp-x86-18-v2"
     <<: *flatpak-steps
 
   build-flatpak-x86-2008:
@@ -55,13 +54,13 @@ jobs:
       image: ubuntu-2004:202010-01
     environment:
       - OCPN_TARGET: flatpak
-      - FLATPAK_BRANCH: beta
     parameters:
       cache-key:
         type: string
-        default: "fp-x86-20-v1"
+        default: "fp-x86-20-v2"
     <<: *flatpak-steps
  
+
   build-macos:
     macos:
       xcode: "11.0.0"

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -17,25 +17,33 @@ sudo apt install flatpak flatpak-builder
 flatpak remote-add --user --if-not-exists \
     flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-# For now, horrible hack: aarch 64 builds are using the updated runtime
-# 20.08 and the opencpn beta version using old 18.08 runtime.
+# aarch64 is built from beta branch, regular x86_64 from stable.
+# Both uses 20.08. Compatibility 18.08 builds are built for
+# x86_64 only using last known 18.08 commit on stable branch.
 
 commit_1808=959f5fd700f72e63182eabb9821b6aa52fb12189eddf72ccf99889977b389447
-if [ "$FLATPAK_BRANCH" = 'beta' ]; then
-        flatpak install --user -y flathub org.freedesktop.Sdk//20.08 >/dev/null
-        flatpak remote-add --user --if-not-exists flathub-beta \
-            https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-        flatpak install --user -y --or-update flathub-beta \
-            org.opencpn.OpenCPN >/dev/null
-        sed -i '/sdk:/s/18.08/20.08/'  flatpak/org.opencpn.*.yaml
+FLATPAK_BRANCH=stable
+if dpkg-architecture --is arm64; then
+    flatpak install --user -y --noninteractive \
+        flathub org.freedesktop.Sdk//20.08
+    flatpak remote-add --user --if-not-exists flathub-beta \
+        https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+    flatpak install --user -y --or-update  --noninteractive \
+        flathub-beta org.opencpn.OpenCPN
+    FLATPAK_BRANCH=beta
+elif [ -n "$BUILD_1808" ]; then
+    flatpak install --user -y --noninteractive \
+        flathub org.freedesktop.Sdk//18.08
+    flatpak install --user -y --or-update --noninteractive \
+        flathub  org.opencpn.OpenCPN
+    flatpak update --user -y --noninteractive --commit $commit_1808 \
+        org.opencpn.OpenCPN
+    sed -i '/sdk:/s/20.08/18.08/'  flatpak/org.opencpn.*.yaml
 else
-        flatpak install --user -y flathub org.freedesktop.Sdk//18.08 >/dev/null
-        flatpak remote-add --user --if-not-exists flathub \
-            https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install --user -y --or-update flathub \
-            org.opencpn.OpenCPN >/dev/null
-        flatpak update --user --commit $commit_1808 org.opencpn.OpenCPN
-        FLATPAK_BRANCH='stable'
+    flatpak install --user -y --noninteractive \
+        flathub org.freedesktop.Sdk//20.08
+    flatpak install --user -y --or-update --noninteractive \
+        flathub  org.opencpn.OpenCPN
 fi
 
 # Patch the runtime version so it matches the nightly builds
@@ -50,6 +58,9 @@ cp .python-version $HOME
 mkdir build; cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j $(nproc) VERBOSE=1 flatpak
+
+# Fix upload script if building 18.08:
+test -n "$BUILD_1808" && sed -i 's/20.08/18.08/' upload.sh
 
 # Restore patched file so the cache checksumming is ok.
 git checkout ../flatpak/$MANIFEST


### PR DESCRIPTION
Update ci/ and .circleci/config to latest shipdriver templates, fixing the flatpak build mess.-